### PR TITLE
Add portland office page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ the cities where we have offices.
 * [Denver](denver.md)
 * [New York City](new-york-city.md)
 * [Philadelphia](philadelphia.md)
+* [Portland](portland.md)
 * [Raleigh](raleigh.md)
 * [San Francisco](san-francisco.md)
 * [Stockholm](stockholm.md)

--- a/portland.md
+++ b/portland.md
@@ -1,0 +1,66 @@
+# Portland
+
+Map for [the thoughtbot Portland office][office].
+
+  [office]: https://goo.gl/maps/q6Pkh
+
+## Coffee
+
+### Around the office
+
+  * [Heart Coffee](https://goo.gl/maps/zgYZt) — Diana's #1
+  * [Courier Coffee](https://goo.gl/maps/pyNtb) — Bernerd's #1
+  * [Stumptown](https://goo.gl/maps/uW2Nf) — Diana's #2
+  * [Barista](https://goo.gl/maps/7kDpp) — Bernerd's #2
+
+### Around town
+
+  * [Coava](https://goo.gl/maps/JYyX1) — Great coffee in the inner SE.
+
+## Coworking spaces
+
+  * [Centrl Office](http://centrloffice.com) (current)
+
+  * [Collective Agency](http://collectiveagency.co)
+
+    > Only have reserved and hot desks, no offices.
+    > $375 reserved desk.
+    > ~$25 off a desk discount available for multiple desks.
+    > Good community there, they have group outings and events.
+    > Didn't spot any startups I remember, but they have all their members on the wall.
+    > What they do, who they are, etc. Probably easy to make meaningful connections here.
+
+  * [FORGE](http://www.forgeportland.org/coworking)
+
+    >  One office available.
+    >  $500 two person office.
+    >  No hard limit on number of people in 2 person office.
+    >  Not sure when a larger office would become available.
+    >  They have an entrepreneur coffee meetup there Wednesday mornings.
+    >  A shopping mobile app and Clinton education initiative backed startup are there.
+
+  * [wework](https://www.wework.com/locations/portland)
+
+## Resources
+
+  * [Portland Startups Switchboard](https://pdxstartups.switchboardhq.com/) — forum connecting local entrepreneurs and startups
+  * [City of Portland Switchboard](https://portland.switchboardhq.com/) — forum connecting local government and business
+  * [Silicon Florist](http://siliconflorist.com/) — Portland startup industry coverage
+  * [Portland Startup Digest](https://www.startupdigest.com/digests/portland)
+
+## User groups
+
+  * [PDX Go](http://www.meetup.com/PDX-Go/) — monthly go meetup
+  * [Portland Ruby Brigade](http://www.meetup.com/Portland-Ruby-Brigade/) — monthly ruby meetup
+  * [brightnight](http://brightnight.club/) — monthly ruby hack night
+
+For more events see [the tech event calendar](http://calagator.org/).
+
+## Designers and developers
+
+Some folks to follow:
+
+* [Porland Dribbblers](http://dribbble.com/designers?location=Portland)
+* [Portland Ruby GitHubbers][portland-rubyists]
+
+  [portland-rubyists]: https://github.com/search?l=Ruby&p=1&q=location%3Aportland&ref=searchresults&type=Users&utf8=%E2%9C%93


### PR DESCRIPTION
Add portland office page,
with a first pass at
some relevant information
based on what other city
pages include.
