### PR TITLE
Add Best Bagel for breakfast in NYC

### DIFF
--- a/new-york-city.md
+++ b/new-york-city.md
@@ -75,6 +75,10 @@ Pizza:
 * [Paulie Gee’s](http://pauliegee.com) – Greenpoint, Brooklyn
 * [Roberta’s](http://robertaspizza.com) – Williamsburg, Brooklyn
 
+Breakfast:
+
+* [Best Bagel and Coffee](https://www.yelp.com/biz/best-bagel-and-coffee-new-york) – 225 W 35th St (between 7th & 8th)
+
 ## Bars
 
 ### Cocktails


### PR DESCRIPTION
This is a popular NYC visitor question: where do we get the best bagel?
If you're near this office, this is the answer.